### PR TITLE
RPM packaging: Remove  nmos-common as build requirement

### DIFF
--- a/rpm/python-mdnsbridge.spec
+++ b/rpm/python-mdnsbridge.spec
@@ -10,7 +10,6 @@ BuildArch:      noarch
 
 BuildRequires:	python2-devel
 BuildRequires:  python-setuptools
-BuildRequires:  nmoscommon
 BuildRequires:	systemd
 
 Requires:       python


### PR DESCRIPTION
nmos-common isn't required to build the rpm