### PR TITLE
mdns bridge should clean up on stop

### DIFF
--- a/mdnsbridge/mdnsbridgeservice.py
+++ b/mdnsbridge/mdnsbridgeservice.py
@@ -52,6 +52,7 @@ class mDNSBridgeService(object):
         self._cleanup()
 
     def stop(self):
+        self._cleanup()
         self.running = False
 
     def _cleanup(self):


### PR DESCRIPTION
- Only makes a difference when the mdnsbridge service is run in stand-alone (rather than service) mode
- Tested with both existing avahi based nmos-common and new zeroconf based nmos-common