### PR TITLE
Use facade class from nmosnode if present, avoiding circular dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS mDNS Bridge Library Changelog
 
+## 0.7.1
+- Use facade class from nmosnode if present
+
 ## 0.7.0
 - Add mDNS bridge client library from nmos-common
 

--- a/mdnsbridge/mdnsbridgeservice.py
+++ b/mdnsbridge/mdnsbridgeservice.py
@@ -4,7 +4,11 @@ import gevent
 import signal
 from systemd import daemon
 from nmoscommon.httpserver import HttpServer
-from nmoscommon.facade import Facade
+try:
+    from nmosnode.facade import Facade
+    NODE_API_PRESENT = True
+except ImportError:
+    NODE_API_PRESENT = False
 from .mdnsbridge import mDNSBridge, mDNSBridgeAPI, APINAME, APIVERSION, APINAMESPACE
 from gevent import monkey
 monkey.patch_all()
@@ -17,7 +21,10 @@ class mDNSBridgeService(object):
     def __init__(self, domain=None):
         self.running = False
         self.registered = False
-        self.facade = Facade("{}/{}".format(APINAME, APIVERSION))
+        if NODE_API_PRESENT:
+            self.facade = Facade("{}/{}".format(APINAME, APIVERSION))
+        else:
+            self.facade = None
         self.domain = domain
 
     def start(self):
@@ -40,17 +47,20 @@ class mDNSBridgeService(object):
     def run(self):
         self.running = True
         self.start()
-        self.facade.register_service("http://" + HOST + ":" + str(PORT),
-                                     "{}/{}/{}/".format(APINAMESPACE, APINAME, APIVERSION))
+        if self.facade:
+            self.facade.register_service("http://" + HOST + ":" + str(PORT),
+                                         "{}/{}/{}/".format(APINAMESPACE, APINAME, APIVERSION))
         daemon.notify("READY=1")
         itercount = 0
         while self.running:
             itercount += 1
             gevent.sleep(1)
             if itercount == 5:  # 5 seconds
-                self.facade.heartbeat_service()
+                if self.facade:
+                    self.facade.heartbeat_service()
                 itercount = 0
-        self.facade.unregister_service()
+        if self.facade:
+            self.facade.unregister_service()
         self._cleanup()
 
     def stop(self):

--- a/mdnsbridge/mdnsbridgeservice.py
+++ b/mdnsbridge/mdnsbridgeservice.py
@@ -8,6 +8,7 @@ try:
     from nmosnode.facade import Facade
     NODE_API_PRESENT = True
 except ImportError:
+    Facade = None
     NODE_API_PRESENT = False
 from .mdnsbridge import mDNSBridge, mDNSBridgeAPI, APINAME, APIVERSION, APINAMESPACE
 from gevent import monkey

--- a/rpm/mdnsbridge.spec
+++ b/rpm/mdnsbridge.spec
@@ -1,7 +1,7 @@
 %global module_name mdnsbridge
 
 Name: 			python-%{module_name}
-Version: 		0.7.0
+Version: 		0.7.1
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		mDNS to HTTP bridge service

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ packages_required = [
 ]
 
 setup(name="mdnsbridge",
-      version="0.7.0",
+      version="0.7.1",
       description="An API providing a DNS-SD/HTTP bridge for AMWA NMOS service types",
       url='https://github.com/bbc/nmos-mdns-bridge',
       author='Peter Brightwell',

--- a/tests/test_mdnsbridgeservice.py
+++ b/tests/test_mdnsbridgeservice.py
@@ -17,6 +17,7 @@ import mock
 import six
 from gevent import signal
 
+
 with mock.patch("mdnsbridge.mdnsbridgeservice.monkey"):
     from mdnsbridge.mdnsbridgeservice import HOST, PORT, mDNSBridgeService
     from mdnsbridge.mdnsbridge import mDNSBridgeAPI, APINAME, APINAMESPACE, APIVERSION
@@ -24,6 +25,7 @@ with mock.patch("mdnsbridge.mdnsbridgeservice.monkey"):
 
 class TestmDNSBridgeService(unittest.TestCase):
     @mock.patch('mdnsbridge.mdnsbridgeservice.Facade')
+    @mock.patch("mdnsbridge.mdnsbridgeservice.NODE_API_PRESENT", True)
     def setUp(self, Facade):
         self.UUT = mDNSBridgeService(domain=mock.sentinel.domain)
         Facade.assert_called_once_with("{}/{}".format(APINAME, APIVERSION))


### PR DESCRIPTION
Can't depend upon the Node API directly as it already depends upon this.