### PR TITLE
Add function raise an exception when no services found or end of list reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NMOS mDNS Bridge Library Changelog
 
 
-## 0.8.1
+## 0.8.2
 - Add method to return list of all service available
 
 ## 0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # NMOS mDNS Bridge Library Changelog
 
 
-## 0.8.2
-- Add method to return list of all service available
+## 0.9.0
+- Add method to raise an exception when no service found or when end of list reached
 
 ## 0.8.1
 - Handle case where txt data includes a boolean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS mDNS Bridge Library Changelog
 
+## 0.7.4
+- Add method to return list of all service available
+
 ## 0.7.3
 - Fix python3 errors
 

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -40,11 +40,11 @@ class IppmDNSBridge(object):
     def getHref(self, srv_type, priority=None, api_ver=None, api_proto=None):
         try:
             try:
-                return self.getHrefWithException(srv_type, priority, api_ver, api_proto, False)
+                return self.getHrefWithException(srv_type, priority, api_ver, api_proto)
             except EndOfServiceList:
                 self.logger.writeInfo("End of Aggregator list, reloading")
                 # Re-try after cache has been updated
-                return self.getHrefWithException(srv_type, priority, api_ver, api_proto, False)
+                return self.getHrefWithException(srv_type, priority, api_ver, api_proto)
         except NoService:
             self.logger.writeWarning("No Aggregator for for {}, priority={}, api_ver={}, api_proto={}".format(
                 srv_type, priority, api_ver, api_proto))
@@ -63,13 +63,13 @@ class IppmDNSBridge(object):
 
         # Flush the cached list of services
         if flush:
-            self._updateServices(srv_type)
+            self.updateServices(srv_type)
 
         # Check if there are any of that type of service, if not do a request
         valid_services = self._getValidServices(srv_type, priority, api_ver, api_proto)
 
         if len(valid_services) == 0:
-            self._updateServices(srv_type)
+            self.updateServices(srv_type)
             valid_services = self._getValidServices(srv_type, priority, api_ver, api_proto)
 
             if len(valid_services) == 0:
@@ -120,7 +120,7 @@ class IppmDNSBridge(object):
         port = service['port']
         return '{}://{}:{}'.format(proto, address, port)
 
-    def _updateServices(self, srv_type):
+    def updateServices(self, srv_type):
         req_url = "http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/"
         try:
             # Request to localhost/x-ipstudio/mdnsbridge/v1.0/<type>/

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -79,7 +79,7 @@ class IppmDNSBridge(object):
 
             if priority >= 100:
                 if service["priority"] == priority:
-                    return self._createHref(service)
+                    return [service]
             else:
                 if service["priority"] < current_priority:
                     current_priority = service["priority"]
@@ -109,7 +109,7 @@ class IppmDNSBridge(object):
                 self.services[srv_type].remove(service)
             return href_list
         else:
-            return [valid_services]
+            return None
 
     def getHref(self, srv_type, priority=None, api_ver=None, api_proto=None):
         valid_services = self._getServiceList(srv_type, priority, api_ver, api_proto)

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -115,11 +115,9 @@ class IppmDNSBridge(object):
         valid_services = self._getServiceList(srv_type, priority, api_ver, api_proto)
 
         if type(valid_services) is list:
-            # Randomise selection. Delete entry from the services list and return it
             service = valid_services.pop(0)
-            href = self._createHref(service)
             self.services[srv_type].remove(service)
-            return href
+            return self._createHref(service)
         else:
             return valid_services
 

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -80,7 +80,7 @@ class IppmDNSBridge(object):
                 if service["priority"] == priority:
                     return self._createHref(service)
             else:
-                if service["priority"] < current_priority:
+                if service["priority"] <= current_priority:
                     current_priority = service["priority"]
                     valid_services = []
                 if service["priority"] == current_priority:

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -81,7 +81,7 @@ class IppmDNSBridge(object):
                 if service["priority"] == priority:
                     return self._createHref(service)
             else:
-                if service["priority"] <= current_priority:
+                if service["priority"] < current_priority:
                     current_priority = service["priority"]
                     valid_services = []
                 if service["priority"] == current_priority:

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -42,11 +42,11 @@ class IppmDNSBridge(object):
             try:
                 return self.getHrefWithException(srv_type, priority, api_ver, api_proto)
             except EndOfServiceList:
-                self.logger.writeInfo("End of Aggregator list, reloading")
+                self.logger.writeInfo("End of DNS-SD service list, reloading")
                 # Re-try after cache has been updated
                 return self.getHrefWithException(srv_type, priority, api_ver, api_proto)
         except NoService:
-            self.logger.writeWarning("No Aggregator for for {}, priority={}, api_ver={}, api_proto={}".format(
+            self.logger.writeWarning("No DNS-SD service for for {}, priority={}, api_ver={}, api_proto={}".format(
                 srv_type, priority, api_ver, api_proto))
             return ""
 
@@ -82,10 +82,7 @@ class IppmDNSBridge(object):
         index = random.randint(0, len(valid_services)-1)
         service = valid_services[index]
         href = self._createHref(service)
-        try:
-            self.services[srv_type].remove(service)
-        except Exception:
-            self.logger.writeInfo("Could not remove service: {}".format(service))
+        self.services[srv_type].remove(service)
 
         return href
 

--- a/rpm/mdnsbridge.spec
+++ b/rpm/mdnsbridge.spec
@@ -1,7 +1,7 @@
 %global module_name mdnsbridge
 
 Name: 			python-%{module_name}
-Version: 		0.7.3
+Version: 		0.7.4
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		mDNS to HTTP bridge service

--- a/rpm/mdnsbridge.spec
+++ b/rpm/mdnsbridge.spec
@@ -1,7 +1,7 @@
 %global module_name mdnsbridge
 
 Name: 			python-%{module_name}
-Version: 		0.8.1
+Version: 		0.8.2
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		mDNS to HTTP bridge service

--- a/rpm/mdnsbridge.spec
+++ b/rpm/mdnsbridge.spec
@@ -1,7 +1,7 @@
 %global module_name mdnsbridge
 
 Name: 			python-%{module_name}
-Version: 		0.8.2
+Version: 		0.9.0
 Release: 		1%{?dist}
 License: 		Internal Licence
 Summary: 		mDNS to HTTP bridge service

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ packages_required = [
 ]
 
 setup(name="mdnsbridge",
-      version="0.7.3",
+      version="0.7.4",
       description="An API providing a DNS-SD/HTTP bridge for AMWA NMOS service types",
       url='https://github.com/bbc/nmos-mdns-bridge',
       author='Peter Brightwell',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ packages_required = [
 ]
 
 setup(name="mdnsbridge",
-      version="0.8.2",
+      version="0.9.0",
       description="An API providing a DNS-SD/HTTP bridge for AMWA NMOS service types",
       url='https://github.com/bbc/nmos-mdns-bridge',
       author='Peter Brightwell',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ packages_required = [
 ]
 
 setup(name="mdnsbridge",
-      version="0.8.1",
+      version="0.8.2",
       description="An API providing a DNS-SD/HTTP bridge for AMWA NMOS service types",
       url='https://github.com/bbc/nmos-mdns-bridge',
       author='Peter Brightwell',

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -358,7 +358,7 @@ class TestIppmDNSBridge(unittest.TestCase):
 
     @mock.patch('requests.get')
     @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
-    def test_gethref_does_not_use_cache_when_flush(self, rand, get):
+    def test_gethref_does_not_use_cache_when_flushed(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
         self.UUT.config['https_mode'] = "disabled"

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -290,7 +290,7 @@ class TestIppmDNSBridge(unittest.TestCase):
     @mock.patch('random.shuffle')
     def test_gethref_second_call_uses_cache(self, rand, get):
         srv_type = "potato"
-        self.UUT.config['priority'] = 99
+        priority = 13
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
@@ -302,11 +302,11 @@ class TestIppmDNSBridge(unittest.TestCase):
         get.side_effect = [mock.DEFAULT, Exception]
         get.return_value.status_code = 200
         get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
-        href = self.UUT.getHref(srv_type)
+        href = self.UUT.getHref(srv_type, priority=priority)
         self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
 
         get.reset_mock()
-        href = self.UUT.getHref(srv_type)
+        href = self.UUT.getHref(srv_type, priority=priority)
         get.assert_not_called()
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -332,7 +332,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         get.reset_mock()
         href = self.UUT.getHref(srv_type)
         get.assert_not_called()
-        self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
+        self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
 
     @mock.patch('requests.get')
     @mock.patch('random.shuffle')

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -14,8 +14,7 @@
 
 import unittest
 import mock
-from mdnsbridge.mdnsbridgeclient import *
-import traceback
+from mdnsbridge.mdnsbridgeclient import IppmDNSBridge
 import json
 
 from nmoscommon.nmoscommonconfig import config as _config
@@ -27,7 +26,7 @@ class TestIppmDNSBridge(unittest.TestCase):
 
     @mock.patch('mdnsbridge.mdnsbridgeclient.Logger')
     def setUp(self, Logger):
-        with mock.patch.dict(_config, { "test" : "active" }):
+        with mock.patch.dict(_config, {"test": "active"}):
             self.UUT = IppmDNSBridge(logger=mock.sentinel.logger)
         Logger.assert_called_once_with("mdnsbridge", mock.sentinel.logger)
         self.logger = Logger.return_value
@@ -37,61 +36,61 @@ class TestIppmDNSBridge(unittest.TestCase):
         pass
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_first_service_with_matching_priority(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 100, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 100, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 100, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 100, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
         ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_first_service_with_matching_priority_including_ipv6(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 100, "protocol" : "http", "address" : "CAFE:FACE:BBC1:BBC2:BBC4:1337:DEED:2323", "port" : 12345, "hostname": None, "versions": DEFAULT_VERSIONS },
-            { "priority" : 100, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": None, "versions": DEFAULT_VERSIONS },
-            { "priority" : 100, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": None, "versions": DEFAULT_VERSIONS },
+            {"priority": 100, "protocol": "http", "address": "CAFE:FACE:BBC1:BBC2:BBC4:1337:DEED:2323", "port": 12345, "hostname": None, "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": None, "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": None, "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[0]["protocol"] + "://[" + services[0]["address"] + "]:" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_only_service_with_matching_priority(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 100, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_only_service_with_matching_version(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
@@ -99,217 +98,210 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.UUT.config['nodefacade']["NODE_REGVERSION"] = "v1.1"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": ["v1.0", "v1.1"] },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": ["v1.2"] },
-            { "priority" : 43, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": ["v1.0"] },
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": ["v1.0", "v1.1"]},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": ["v1.2"]},
+            {"priority": 43, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": ["v1.0"]},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type, None, "v1.1", None)
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_only_service_with_matching_protocol_https(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
         self.UUT.config['https_mode'] = "enabled"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 43, "protocol" : "https", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 43, "protocol": "https", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type, None, None, "https")
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_only_service_with_matching_protocol_http(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 97, "protocol" : "https", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "https", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 43, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "https", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "https", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 43, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type, None, None, "http")
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_only_service_with_matching_priority_https(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "enabled"
 
         services = [
-            { "priority" : 97, "protocol" : "https", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "https", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 100, "protocol" : "https", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "https", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "https", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "https", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_lowest_priority_service_when_none_match(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 99
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 53, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=3) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_when_multiple_services_have_same_priority_return_one_at_random(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 99
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 53, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address3", "port" : 12348, "hostname": "service_host3", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address4", "port" : 12349, "hostname": "service_host4", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address5", "port" : 12350, "hostname": "service_host5", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address6", "port" : 12351, "hostname": "service_host6", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address3", "port": 12348, "hostname": "service_host3", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address4", "port": 12349, "hostname": "service_host4", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address5", "port": 12350, "hostname": "service_host5", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address6", "port": 12351, "hostname": "service_host6", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
-        self.assertEqual(href, services[5]["protocol"] + "://" + services[5]["address"] + ":" + str(services[5]["port"]))
+        self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_empty_string_when_no_matching_services(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 100, "protocol" : "https", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 53, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 100, "protocol": "https", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, "")
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_empty_string_when_no_matching_services_https(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "enabled"
 
         services = [
-            { "priority" : 100, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 53, "protocol" : "https", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 100, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 53, "protocol": "https", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, "")
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_local_service_when_no_matching_query_service(self, rand, get):
         srv_type = "nmos-query"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 53, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.return_value.status_code=200
-        get.return_value.json.side_effect = [ { "representation" : json.loads(json.dumps(services)) }, mock.sentinel.SHOULD_BE_IGNORED ]
+        get.return_value.status_code = 200
+        get.return_value.json.side_effect = [{"representation": json.loads(json.dumps(services))}, mock.sentinel.SHOULD_BE_IGNORED]
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, "http://127.0.0.1/x-nmos/query/v1.0/")
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_empty_string_when_no_matching_query_service_including_local(self, rand, get):
         srv_type = "nmos-query"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 53, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.side_effect = [ mock.DEFAULT, Exception ]
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.side_effect = [mock.DEFAULT, Exception]
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, "")
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_returns_empty_string_when_request_fails(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
-        services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 53, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
-            ]
-
-        get.side_effect=Exception
+        get.side_effect = Exception
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, "")
 
-
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_second_call_uses_cache(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 99
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 97, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            { "priority" : 13, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-            { "priority" : 13, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 13, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.side_effect = [ mock.DEFAULT, Exception ]
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.side_effect = [mock.DEFAULT, Exception]
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
 
@@ -318,23 +310,22 @@ class TestIppmDNSBridge(unittest.TestCase):
         get.assert_not_called()
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
-
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_second_call_uses_cache_at_high_priority(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 100, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            { "priority" : 100, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-            { "priority" : 100, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
-        get.side_effect = [ mock.DEFAULT, Exception ]
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.side_effect = [mock.DEFAULT, Exception]
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
@@ -344,31 +335,31 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_second_call_rechecks_if_only_low_priority_servers_exist(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 200, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 300, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 400, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
+            {"priority": 200, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 300, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 400, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
             ]
 
         second_services = [
-            { "priority" : 200, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS },
-            { "priority" : 300, "protocol" : "http", "address" : "service_address1", "port" : 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS },
-            { "priority" : 400, "protocol" : "http", "address" : "service_address2", "port" : 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS },
-            { "priority" : 100, "protocol" : "http", "address" : "service_address3", "port" : 12348, "hostname": "service_host3", "versions": DEFAULT_VERSIONS },
+            {"priority": 200, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 300, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 400, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
+            {"priority": 100, "protocol": "http", "address": "service_address3", "port": 12348, "hostname": "service_host3", "versions": DEFAULT_VERSIONS},
             ]
 
-        getmocks = [ mock.MagicMock(name="get1()"), mock.MagicMock(name="get2()") ]
-        get.side_effect = [ getmocks[0], getmocks[1] ]
-        getmocks[0].status_code=200
-        getmocks[0].json.return_value = { "representation" : json.loads(json.dumps(services)) }
-        getmocks[1].status_code=200
-        getmocks[1].json.return_value = { "representation" : json.loads(json.dumps(second_services)) }
+        getmocks = [mock.MagicMock(name="get1()"), mock.MagicMock(name="get2()")]
+        get.side_effect = [getmocks[0], getmocks[1]]
+        getmocks[0].status_code = 200
+        getmocks[0].json.return_value = {"representation": json.loads(json.dumps(services))}
+        getmocks[1].status_code = 200
+        getmocks[1].json.return_value = {"representation": json.loads(json.dumps(second_services))}
         href = self.UUT.getHref(srv_type)
         get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
         self.assertEqual(href, "")
@@ -379,23 +370,23 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, second_services[3]["protocol"] + "://" + second_services[3]["address"] + ":" + str(second_services[3]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_handles_missing_hostname(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
         self.UUT.config['https_mode'] = "disabled"
 
         services = [
-            { "priority" : 100, "protocol" : "http", "address" : "service_address0", "port" : 12345 },
+            {"priority": 100, "protocol": "http", "address": "service_address0", "port": 12345},
         ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0) # guaranteed random, chosen by roll of fair die
+    @mock.patch('random.shuffle')
     def test_gethref_handles_prefer_hostnames(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -403,10 +394,10 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.UUT.config['prefer_hostnames'] = True
 
         services = [
-            { "priority" : 100, "protocol" : "http", "address" : "service_address0", "port" : 12345, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS },
+            {"priority": 100, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS},
         ]
 
-        get.return_value.status_code=200
-        get.return_value.json.return_value = { "representation" : json.loads(json.dumps(services)) }
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["hostname"] + ":" + str(services[0]["port"]))

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -401,3 +401,39 @@ class TestIppmDNSBridge(unittest.TestCase):
         get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["hostname"] + ":" + str(services[0]["port"]))
+
+    @mock.patch('requests.get')
+    @mock.patch('random.shuffle')
+    def test_gethref_list_returns_list_of_services(self, rand, get):
+        srv_type = "potato"
+        self.UUT.config['priority'] = 10
+        self.UUT.config['https_mode'] = "disabled"
+        self.UUT.config['prefer_hostnames'] = True
+
+        services = [
+            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS},
+        ]
+
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
+        href_list = self.UUT.getHrefList(srv_type)
+        self.assertEqual(href_list[0], services[0]["protocol"] + "://" + services[0]["hostname"] + ":" + str(services[0]["port"]))
+
+    @mock.patch('requests.get')
+    @mock.patch('random.shuffle')
+    def test_gethref_list_returns_list_of_single_service(self, rand, get):
+        srv_type = "potato"
+        self.UUT.config['priority'] = 101
+        self.UUT.config['https_mode'] = "disabled"
+        self.UUT.config['prefer_hostnames'] = True
+
+        services = [
+            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS},
+            {"priority": 101, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS},
+            {"priority": 12, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS}
+        ]
+
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
+        href_list = self.UUT.getHrefList(srv_type)
+        self.assertEqual(href_list[0], services[1]["protocol"] + "://" + services[1]["hostname"] + ":" + str(services[1]["port"]))

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -36,7 +36,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         pass
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_first_service_with_matching_priority(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -54,7 +54,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_first_service_with_matching_priority_including_ipv6(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -72,7 +72,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[0]["protocol"] + "://[" + services[0]["address"] + "]:" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_only_service_with_matching_priority(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -90,7 +90,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_only_service_with_matching_version(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
@@ -109,7 +109,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_only_service_with_matching_protocol_https(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
@@ -127,7 +127,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_only_service_with_matching_protocol_http(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
@@ -145,7 +145,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_only_service_with_matching_priority_https(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -163,7 +163,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_lowest_priority_service_when_none_match(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 99
@@ -181,7 +181,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=3)  # guaranteed random, chosen by roll of fair die
     def test_gethref_when_multiple_services_have_same_priority_return_one_at_random(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 99
@@ -200,10 +200,10 @@ class TestIppmDNSBridge(unittest.TestCase):
         get.return_value.status_code = 200
         get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
-        self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
+        self.assertEqual(href, services[5]["protocol"] + "://" + services[5]["address"] + ":" + str(services[5]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_empty_string_when_no_matching_services(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -221,7 +221,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, "")
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_empty_string_when_no_matching_services_https(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -239,7 +239,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, "")
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_local_service_when_no_matching_query_service(self, rand, get):
         srv_type = "nmos-query"
         self.UUT.config['priority'] = 100
@@ -257,7 +257,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, "http://127.0.0.1/x-nmos/query/v1.0/")
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_empty_string_when_no_matching_query_service_including_local(self, rand, get):
         srv_type = "nmos-query"
         self.UUT.config['priority'] = 100
@@ -276,7 +276,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, "")
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_empty_string_when_request_fails(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -287,7 +287,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, "")
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_second_call_uses_cache(self, rand, get):
         srv_type = "potato"
         priority = 13
@@ -311,7 +311,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_second_call_uses_cache_at_high_priority(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -335,7 +335,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[1]["protocol"] + "://" + services[1]["address"] + ":" + str(services[1]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_second_call_rechecks_if_only_low_priority_servers_exist(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -370,7 +370,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, second_services[3]["protocol"] + "://" + second_services[3]["address"] + ":" + str(second_services[3]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_handles_missing_hostname(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -386,7 +386,7 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_handles_prefer_hostnames(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -403,37 +403,34 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["hostname"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
-    def test_gethref_list_returns_list_of_services(self, rand, get):
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
+    def test_gethref_does_not_use_cache_when_flush(self, rand, get):
         srv_type = "potato"
-        self.UUT.config['priority'] = 10
+        self.UUT.config['priority'] = 0
         self.UUT.config['https_mode'] = "disabled"
-        self.UUT.config['prefer_hostnames'] = True
 
         services = [
-            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS},
-        ]
+            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 20, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 30, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
+            ]
 
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
-        href_list = self.UUT.getHrefList(srv_type)
-        self.assertEqual(href_list[0], services[0]["protocol"] + "://" + services[0]["hostname"] + ":" + str(services[0]["port"]))
+        second_services = [
+            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 22345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 0, "protocol": "http", "address": "service_address1", "port": 22346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            ]
 
-    @mock.patch('requests.get')
-    @mock.patch('random.shuffle')
-    def test_gethref_list_returns_list_of_single_service(self, rand, get):
-        srv_type = "potato"
-        self.UUT.config['priority'] = 101
-        self.UUT.config['https_mode'] = "disabled"
-        self.UUT.config['prefer_hostnames'] = True
+        getmocks = [mock.MagicMock(name="get1()"), mock.MagicMock(name="get2()")]
+        get.side_effect = [getmocks[0], getmocks[1]]
+        getmocks[0].status_code = 200
+        getmocks[0].json.return_value = {"representation": json.loads(json.dumps(services))}
+        getmocks[1].status_code = 200
+        getmocks[1].json.return_value = {"representation": json.loads(json.dumps(second_services))}
+        href = self.UUT.getHref(srv_type, flush=True)
+        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
+        self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
-        services = [
-            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS},
-            {"priority": 101, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS},
-            {"priority": 12, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_hostname0", "versions": DEFAULT_VERSIONS}
-        ]
-
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
-        href_list = self.UUT.getHrefList(srv_type)
-        self.assertEqual(href_list[0], services[1]["protocol"] + "://" + services[1]["hostname"] + ":" + str(services[1]["port"]))
+        get.reset_mock()
+        href = self.UUT.getHref(srv_type, flush=True)
+        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
+        self.assertEqual(href, second_services[1]["protocol"] + "://" + second_services[1]["address"] + ":" + str(second_services[1]["port"]))

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -262,43 +262,6 @@ class TestIppmDNSBridge(unittest.TestCase):
 
     @mock.patch('requests.get')
     @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
-    def test_gethref_returns_local_service_when_no_matching_query_service(self, rand, get):
-        srv_type = "nmos-query"
-        self.UUT.config['priority'] = 100
-        self.UUT.config['https_mode'] = "disabled"
-
-        services = [
-            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
-            ]
-
-        get.return_value.status_code = 200
-        get.return_value.json.side_effect = [{"representation": json.loads(json.dumps(services))}, mock.sentinel.SHOULD_BE_IGNORED]
-        href = self.UUT.getHref(srv_type)
-        self.assertEqual(href, "http://127.0.0.1/x-nmos/query/v1.0/")
-
-    @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
-    def test_gethref_returns_empty_string_when_no_matching_query_service_including_local(self, rand, get):
-        srv_type = "nmos-query"
-        self.UUT.config['priority'] = 100
-        self.UUT.config['https_mode'] = "disabled"
-
-        services = [
-            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            {"priority": 13, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
-            ]
-
-        get.side_effect = [mock.DEFAULT, Exception]
-        get.return_value.status_code = 200
-        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
-        href = self.UUT.getHref(srv_type)
-        self.assertEqual(href, "")
-
-    @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_empty_string_when_request_fails(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -380,12 +380,12 @@ class TestIppmDNSBridge(unittest.TestCase):
         getmocks[0].json.return_value = {"representation": json.loads(json.dumps(services))}
         getmocks[1].status_code = 200
         getmocks[1].json.return_value = {"representation": json.loads(json.dumps(second_services))}
-        href = self.UUT.getHref(srv_type, flush=True)
+        href = self.UUT.getHrefWithException(srv_type, flush=True)
         get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
 
         get.reset_mock()
-        href = self.UUT.getHref(srv_type, flush=True)
+        href = self.UUT.getHrefWithException(srv_type, flush=True)
         get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
         self.assertEqual(href, second_services[1]["protocol"] + "://" + second_services[1]["address"] + ":" + str(second_services[1]["port"]))
 

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -203,6 +203,28 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[5]["protocol"] + "://" + services[5]["address"] + ":" + str(services[5]["port"]))
 
     @mock.patch('requests.get')
+    @mock.patch('random.randint', return_value=4)  # guaranteed random, chosen by roll of fair die
+    def test_gethref_when_multiple_high_priority_services_have_same_priority_return_one_at_random(self, rand, get):
+        srv_type = "potato"
+        self.UUT.config['priority'] = 102
+        self.UUT.config['https_mode'] = "disabled"
+
+        services = [
+            {"priority": 97, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 102, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 53, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
+            {"priority": 102, "protocol": "http", "address": "service_address3", "port": 12348, "hostname": "service_host3", "versions": DEFAULT_VERSIONS},
+            {"priority": 102, "protocol": "http", "address": "service_address4", "port": 12349, "hostname": "service_host4", "versions": DEFAULT_VERSIONS},
+            {"priority": 102, "protocol": "http", "address": "service_address5", "port": 12350, "hostname": "service_host5", "versions": DEFAULT_VERSIONS},
+            {"priority": 102, "protocol": "http", "address": "service_address6", "port": 12351, "hostname": "service_host6", "versions": DEFAULT_VERSIONS},
+            ]
+
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
+        href = self.UUT.getHref(srv_type)
+        self.assertEqual(href, services[6]["protocol"] + "://" + services[6]["address"] + ":" + str(services[6]["port"]))
+
+    @mock.patch('requests.get')
     @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_returns_empty_string_when_no_matching_services(self, rand, get):
         srv_type = "potato"
@@ -336,6 +358,39 @@ class TestIppmDNSBridge(unittest.TestCase):
 
     @mock.patch('requests.get')
     @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
+    def test_gethref_does_not_use_cache_when_flush(self, rand, get):
+        srv_type = "potato"
+        self.UUT.config['priority'] = 0
+        self.UUT.config['https_mode'] = "disabled"
+
+        services = [
+            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 20, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            {"priority": 30, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
+            ]
+
+        second_services = [
+            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 22345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
+            {"priority": 0, "protocol": "http", "address": "service_address1", "port": 22346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
+            ]
+
+        getmocks = [mock.MagicMock(name="get1()"), mock.MagicMock(name="get2()")]
+        get.side_effect = [getmocks[0], getmocks[1]]
+        getmocks[0].status_code = 200
+        getmocks[0].json.return_value = {"representation": json.loads(json.dumps(services))}
+        getmocks[1].status_code = 200
+        getmocks[1].json.return_value = {"representation": json.loads(json.dumps(second_services))}
+        href = self.UUT.getHref(srv_type, flush=True)
+        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
+        self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
+
+        get.reset_mock()
+        href = self.UUT.getHref(srv_type, flush=True)
+        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
+        self.assertEqual(href, second_services[1]["protocol"] + "://" + second_services[1]["address"] + ":" + str(second_services[1]["port"]))
+
+    @mock.patch('requests.get')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
     def test_gethref_second_call_rechecks_if_only_low_priority_servers_exist(self, rand, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 100
@@ -401,36 +456,3 @@ class TestIppmDNSBridge(unittest.TestCase):
         get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
         href = self.UUT.getHref(srv_type)
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["hostname"] + ":" + str(services[0]["port"]))
-
-    @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
-    def test_gethref_does_not_use_cache_when_flush(self, rand, get):
-        srv_type = "potato"
-        self.UUT.config['priority'] = 0
-        self.UUT.config['https_mode'] = "disabled"
-
-        services = [
-            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            {"priority": 20, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-            {"priority": 30, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
-            ]
-
-        second_services = [
-            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 22345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            {"priority": 0, "protocol": "http", "address": "service_address1", "port": 22346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-            ]
-
-        getmocks = [mock.MagicMock(name="get1()"), mock.MagicMock(name="get2()")]
-        get.side_effect = [getmocks[0], getmocks[1]]
-        getmocks[0].status_code = 200
-        getmocks[0].json.return_value = {"representation": json.loads(json.dumps(services))}
-        getmocks[1].status_code = 200
-        getmocks[1].json.return_value = {"representation": json.loads(json.dumps(second_services))}
-        href = self.UUT.getHref(srv_type, flush=True)
-        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
-        self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
-
-        get.reset_mock()
-        href = self.UUT.getHref(srv_type, flush=True)
-        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
-        self.assertEqual(href, second_services[1]["protocol"] + "://" + second_services[1]["address"] + ":" + str(second_services[1]["port"]))


### PR DESCRIPTION
 So support for exponential backoff can be added to the Node API, when registry's return 5xx