### PR TITLE
Check for `authorization` field in mdns client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS mDNS Bridge Library Changelog
 
+## 0.9.2
+- Add `api_auth` parameter to MDNS Client
+
 ## 0.9.1
 - Alter executable to run using Python3, alter `stdeb` to replace python 2 package, call `cleanup` in stop()
 

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -46,7 +46,7 @@ class IppmDNSBridge(object):
                 # Re-try after cache has been updated
                 return self.getHrefWithException(srv_type, priority, api_ver, api_proto, api_auth)
         except NoService:
-            self.logger.writeWarning("No DNS-SD service for for {}, priority={}, api_ver={}, api_proto={}".format(
+            self.logger.writeWarning("No DNS-SD service for {}, priority={}, api_ver={}, api_proto={}".format(
                 srv_type, priority, api_ver, api_proto))
             return ""
 
@@ -75,7 +75,7 @@ class IppmDNSBridge(object):
 
         # Randomise selection. Delete entry from the cached list of services and return it
         random.seed()
-        index = random.randint(0, len(valid_services)-1)
+        index = random.randint(0, len(valid_services) - 1)
         service = valid_services[index]
         href = self._createHref(service)
         self.services[srv_type].remove(service)

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -37,7 +37,7 @@ class IppmDNSBridge(object):
         self.config = {}
         self.config.update(_config)
 
-    def getHref(self, srv_type, priority=None, api_ver=None, api_proto=None, api_auth=False):
+    def getHref(self, srv_type, priority=None, api_ver=None, api_proto=None, api_auth=None):
         try:
             try:
                 return self.getHrefWithException(srv_type, priority, api_ver, api_proto, api_auth)
@@ -50,7 +50,7 @@ class IppmDNSBridge(object):
                 srv_type, priority, api_ver, api_proto))
             return ""
 
-    def getHrefWithException(self, srv_type, priority=None, api_ver=None, api_proto=None, api_auth=False):
+    def getHrefWithException(self, srv_type, priority=None, api_ver=None, api_proto=None, api_auth=None):
         if priority is None:
             priority = self.config["priority"]
 
@@ -82,7 +82,7 @@ class IppmDNSBridge(object):
 
         return href
 
-    def _getValidServices(self, srv_type, priority, api_ver=None, api_proto=None, api_auth=False):
+    def _getValidServices(self, srv_type, priority, api_ver=None, api_proto=None, api_auth=None):
         current_priority = 99
         valid_services = []
         for service in self.services[srv_type]:
@@ -90,7 +90,7 @@ class IppmDNSBridge(object):
                 continue
             if api_proto is not None and api_proto != service["protocol"]:
                 continue
-            if api_auth != service.get("authorization", False):
+            if api_auth is not None and api_auth != service.get("authorization", False):
                 continue
             if priority >= 100:
                 if service["priority"] == priority:

--- a/mdnsbridge/mdnsbridgeclient.py
+++ b/mdnsbridge/mdnsbridgeclient.py
@@ -46,8 +46,9 @@ class IppmDNSBridge(object):
                 # Re-try after cache has been updated
                 return self.getHrefWithException(srv_type, priority, api_ver, api_proto, api_auth)
         except NoService:
-            self.logger.writeWarning("No DNS-SD service for {}, priority={}, api_ver={}, api_proto={}".format(
-                srv_type, priority, api_ver, api_proto))
+            self.logger.writeWarning(
+                "No DNS-SD service for {}, priority={}, api_ver={}, api_proto={}, api_auth={}".format(
+                    srv_type, priority, api_ver, api_proto, api_auth))
             return ""
 
     def getHrefWithException(self, srv_type, priority=None, api_ver=None, api_proto=None, api_auth=None):

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ packages_required = [
 
 setup(
     name="mdnsbridge",
-    version="0.9.1",
+    version="0.9.2",
     description="An API providing a DNS-SD/HTTP bridge for AMWA NMOS service types",
     url='https://github.com/bbc/nmos-mdns-bridge',
     author='Peter Brightwell',

--- a/tests/test_mdnsbridge.py
+++ b/tests/test_mdnsbridge.py
@@ -129,8 +129,7 @@ class TestmDNSBridge(unittest.TestCase):
 
     def assert_registered_callback_correctly_handles_data_from_mdns(
             self, type, action, name, address=None,
-            prefer_ipv6=False, expect_no_add=False, priority=100
-            ):
+            prefer_ipv6=False, expect_no_add=False, priority=100):
         expected = {'protocol': 'http',
                     'hostname': 'test.example.com',
                     'name': name,

--- a/tests/test_mdnsbridgeclient.py
+++ b/tests/test_mdnsbridgeclient.py
@@ -389,39 +389,6 @@ class TestIppmDNSBridge(unittest.TestCase):
         self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["hostname"] + ":" + str(services[0]["port"]))
 
     @mock.patch('requests.get')
-    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
-    def test_gethrefwithexception_does_not_use_cache_when_flushed(self, rand, get):
-        srv_type = "potato"
-        self.UUT.config['priority'] = 0
-        self.UUT.config['https_mode'] = "disabled"
-
-        services = [
-            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            {"priority": 20, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-            {"priority": 30, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS},
-        ]
-
-        second_services = [
-            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 22345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            {"priority": 0, "protocol": "http", "address": "service_address1", "port": 22346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-        ]
-
-        getmocks = [mock.MagicMock(name="get1()"), mock.MagicMock(name="get2()")]
-        get.side_effect = [getmocks[0], getmocks[1]]
-        getmocks[0].status_code = 200
-        getmocks[0].json.return_value = {"representation": json.loads(json.dumps(services))}
-        getmocks[1].status_code = 200
-        getmocks[1].json.return_value = {"representation": json.loads(json.dumps(second_services))}
-        href = self.UUT.getHrefWithException(srv_type, flush=True)
-        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
-        self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
-
-        get.reset_mock()
-        href = self.UUT.getHrefWithException(srv_type, flush=True)
-        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
-        self.assertEqual(href, second_services[1]["protocol"] + "://" + second_services[1]["address"] + ":" + str(second_services[1]["port"]))
-
-    @mock.patch('requests.get')
     def test_gethrefwithexception_does_raises_noservice_exception(self, get):
         srv_type = "potato"
         self.UUT.config['priority'] = 0
@@ -449,22 +416,10 @@ class TestIppmDNSBridge(unittest.TestCase):
             {"priority": 0, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
         ]
 
-        second_services = [
-            {"priority": 10, "protocol": "http", "address": "service_address0", "port": 22345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS},
-            {"priority": 0, "protocol": "http", "address": "service_address1", "port": 22346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS},
-        ]
-
-        getmocks = [mock.MagicMock(name="get1()"), mock.MagicMock(name="get2()")]
-        get.side_effect = [getmocks[0], getmocks[1]]
+        getmocks = [mock.MagicMock(name="get1()")]
+        get.side_effect = [getmocks[0]]
         getmocks[0].status_code = 200
         getmocks[0].json.return_value = {"representation": json.loads(json.dumps(services))}
-        getmocks[1].status_code = 200
-        getmocks[1].json.return_value = {"representation": json.loads(json.dumps(second_services))}
-        href = self.UUT.getHrefWithException(srv_type, flush=True)
-        get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
-        self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
-
-        get.reset_mock()
 
         with self.assertRaises(EndOfServiceList):
             self.UUT.getHrefWithException(srv_type)
@@ -472,4 +427,27 @@ class TestIppmDNSBridge(unittest.TestCase):
         get.assert_called_once_with("http://127.0.0.1/x-ipstudio/mdnsbridge/v1.0/" + srv_type + "/", timeout=0.5, proxies={'http': ''})
 
         href = self.UUT.getHrefWithException(srv_type)
-        self.assertEqual(href, second_services[1]["protocol"] + "://" + second_services[1]["address"] + ":" + str(second_services[1]["port"]))
+        self.assertEqual(href, services[0]["protocol"] + "://" + services[0]["address"] + ":" + str(services[0]["port"]))
+
+    @mock.patch('requests.get')
+    @mock.patch('random.randint', return_value=0)  # guaranteed random, chosen by roll of fair die
+    def test_gethref_returns_service_with_correct_authorization(self, rand, get):
+        srv_type = "potato"
+        self.UUT.config['priority'] = 0
+        self.UUT.config['https_mode'] = "disabled"
+
+        services = [
+            {"priority": 0, "protocol": "http", "address": "service_address0", "port": 12345, "hostname": "service_host0", "versions": DEFAULT_VERSIONS, "authorization": False},
+            {"priority": 0, "protocol": "http", "address": "service_address1", "port": 12346, "hostname": "service_host1", "versions": DEFAULT_VERSIONS, "authorization": False},
+            {"priority": 0, "protocol": "http", "address": "service_address2", "port": 12347, "hostname": "service_host2", "versions": DEFAULT_VERSIONS, "authorization": True},
+            {"priority": 0, "protocol": "http", "address": "service_address2", "port": 12348, "hostname": "service_host3", "versions": DEFAULT_VERSIONS, "authorization": True}
+        ]
+
+        get.return_value.status_code = 200
+        get.return_value.json.return_value = {"representation": json.loads(json.dumps(services))}
+        href = self.UUT.getHref(srv_type, api_auth=True)
+        self.assertEqual(href, services[2]["protocol"] + "://" + services[2]["address"] + ":" + str(services[2]["port"]))
+
+        href = self.UUT.getHrefWithException(srv_type, api_auth=True)
+        self.assertEqual(href, services[3]["protocol"] + "://" + services[3]["address"] + ":" + str(services[3]["port"]))
+

--- a/tests/test_mdnsbridgeservice.py
+++ b/tests/test_mdnsbridgeservice.py
@@ -16,7 +16,7 @@ import unittest
 import mock
 import six
 from gevent import signal
-from cysystemd.daemon import Notification 
+from cysystemd.daemon import Notification
 
 
 with mock.patch("mdnsbridge.mdnsbridgeservice.monkey"):
@@ -38,9 +38,8 @@ class TestmDNSBridgeService(unittest.TestCase):
     @mock.patch('mdnsbridge.mdnsbridgeservice.HttpServer')
     @mock.patch('mdnsbridge.mdnsbridgeservice.daemon')
     def assert_run_starts_runs_and_stops_as_expected(
-        self, n, daemon, HttpServer, mDNSBridge, sleep,
-        gevent_signal, http_server_fails_with_exception=None
-            ):
+            self, n, daemon, HttpServer, mDNSBridge, sleep,
+            gevent_signal, http_server_fails_with_exception=None):
         HttpServer.return_value.started.is_set.side_effect = [False, False, False, True]
         HttpServer.return_value.failed = http_server_fails_with_exception
 
@@ -85,7 +84,7 @@ class TestmDNSBridgeService(unittest.TestCase):
             )
             daemon.notify.assert_called_once_with(Notification.READY)
             self.assertListEqual(
-                self.UUT.facade.heartbeat_service.mock_calls, [mock.call() for x in range(0, len(responses)//5)]
+                self.UUT.facade.heartbeat_service.mock_calls, [mock.call() for x in range(0, len(responses) // 5)]
             )
             self.UUT.facade.unregister_service.assert_called_once_with()
             HttpServer.return_value.stop.assert_called_once_with()


### PR DESCRIPTION
Uses the `api_auth` field in the mdns text records to determine which records to return